### PR TITLE
udev rule also applies to bootloader mode

### DIFF
--- a/raspberry_pi_4b_setup/usb_configuration.rst
+++ b/raspberry_pi_4b_setup/usb_configuration.rst
@@ -9,7 +9,7 @@ Create the file :file:`/etc/udev/rules.d/50-pixracer.rules` and add the followin
 
    KERNEL=="ttyACM[0-9]*", GROUP="dialout", ENV{FCU_USB}="fcu_usb"
 
-   ENV{FCU_USB}=="fcu_usb", SUBSYSTEM=="tty", ATTRS{product}=="PX4 FMU v4.x", SYMLINK+="fcu_usb"
+   ENV{FCU_USB}=="fcu_usb", SUBSYSTEM=="tty", ATTRS{idVendor}=="26ac", ATTRS{idProduct}=="0012", SYMLINK+="fcu_usb"
 
 Retrigger the rules:
 


### PR DESCRIPTION
the previous rule did not apply to the bootlader mode since the product
signature changes. product and vendor id stay the same and are
preferable to identify the FCU.