### PR TITLE
use stable px4 release

### DIFF
--- a/getting_started/installing_px4.rst
+++ b/getting_started/installing_px4.rst
@@ -12,7 +12,7 @@ Get The Code
 
 .. code-block:: sh
 
-    git clone --recursive https://github.com/PX4/PX4-Autopilot.git
+    git clone --branch v1.12.3 --recursive https://github.com/PX4/PX4-Autopilot.git
 
 
 Export Environment Variables


### PR DESCRIPTION
Automatically checkout stable px4 release [v1.12.3](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.12.3) after cloning. Currently, we use the main which is potentially not working with our code.